### PR TITLE
fix: apipath fix on windows platform

### DIFF
--- a/lib/loaders/entry-loader.js
+++ b/lib/loaders/entry-loader.js
@@ -1,7 +1,9 @@
 const path = require('path');
 const loaderUtils = require('loader-utils');
-const apiPath = path.join(__dirname, 'api.js');
-
+var apiPath = path.join(__dirname, 'api.js')
+if(/win32/gi.test(process.platform)){
+  apiPath = apiPath.replace(/\\/g,'\\\\')
+}
 module.exports = function() {
   const { activationUrl, ips } = loaderUtils.getOptions(this) || {};
 


### PR DESCRIPTION
A Windows path problem.
[#L3](https://github.com/liximomo/lazy-compile-webpack-plugin/blob/master/lib/loaders/entry-loader.js#L3)
It should be `apiPath.replace(/\\/ig,'\\\\')`.Otherwise,the program will transform `E:\code\app.js` into `E:codeapp.js` at [ line 11](https://github.com/liximomo/lazy-compile-webpack-plugin/blob/master/lib/loaders/entry-loader.js#L11) because of the template code.
Just make a judgement it'll runs ok!