### PR TITLE
prevent activation of module that are already compiled, remove initial activation

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -60,9 +60,13 @@ class LazyCompilePlugin {
     }
 
     const moduleInfo = this._lazyModules.get(id);
-    if (moduleInfo) {
+    const status = moduleInfo.status;
+    if (
+      moduleInfo &&
+      (status === ModuleStatus.INIT || status === ModuleStatus.BLOCKED)
+    ) {
       moduleInfo.status = ModuleStatus.READY;
-      return this._recompile(moduleInfo.filename);
+      await this._recompile(moduleInfo.filename);
     }
   }
 
@@ -92,8 +96,8 @@ class LazyCompilePlugin {
       }
     );
 
-    compiler.hooks.compilation.tap('LazyCompilePlugin', compilation => {
-      compilation.hooks.buildModule.tap('LazyCompilePlugin', wpModule => {
+    compiler.hooks.compilation.tap('LazyCompilePlugin', (compilation) => {
+      compilation.hooks.buildModule.tap('LazyCompilePlugin', (wpModule) => {
         const id = getModuleId(wpModule);
         if (!this._lazyModules.has(id)) {
           return;
@@ -126,10 +130,7 @@ class LazyCompilePlugin {
       });
     });
 
-    compiler.hooks.done.tap('LazyCompilePlugin', () => {
-      if (this._firstCompileDone) return;
-
-      this._pendingActivation.forEach(id => this.activateModule(id));
+    compiler.hooks.done.tapPromise('LazyCompilePlugin', async () => {
       this._firstCompileDone = true;
     });
   }
@@ -143,7 +144,7 @@ class LazyCompilePlugin {
   }
 
   async _recompile(filename) {
-    return new Promise((resolve, reject) => {
+    await new Promise((resolve, reject) => {
       const now = new Date();
 
       // trigger watcher to recompile


### PR DESCRIPTION
In my experience, browser will send request for files that are already ready and sent to it before. Therefore blocking these requests.
I played around and didn't find the use case for initial activate module either, as the only reason `this.pendingActivation` would have value, is because browser requested for it from server.js. However on the initial build, dev server didn't even start, therefore there shouldn't be any request coming in.